### PR TITLE
Added support for universal framework targets and Carthage.

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "mrackwitz/xcconfigs"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,1 @@
+github "mrackwitz/xcconfigs" "3.0"

--- a/SwiftSequence.xcodeproj/project.pbxproj
+++ b/SwiftSequence.xcodeproj/project.pbxproj
@@ -94,6 +94,9 @@
 		70CB76D51C13BFC0003A7461 /* TakeDropTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TakeDropTests.swift; sourceTree = "<group>"; };
 		70CB76D61C13BFC0003A7461 /* TestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		70CB76D71C13BFC0003A7461 /* ZipTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZipTests.swift; sourceTree = "<group>"; };
+		BF9C11AC1D03566700449EA6 /* UniversalFramework_Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = UniversalFramework_Base.xcconfig; sourceTree = "<group>"; };
+		BF9C11AD1D03566700449EA6 /* UniversalFramework_Framework.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = UniversalFramework_Framework.xcconfig; sourceTree = "<group>"; };
+		BF9C11AE1D03566700449EA6 /* UniversalFramework_Test.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = UniversalFramework_Test.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -120,6 +123,7 @@
 			children = (
 				707F996C1C13B9EA00CE1A23 /* Sources */,
 				707F99781C13B9EB00CE1A23 /* Tests */,
+				BF9C11A71D03566700449EA6 /* Configurations */,
 				707F996B1C13B9EA00CE1A23 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -182,6 +186,17 @@
 				707F997B1C13B9EB00CE1A23 /* Info.plist */,
 			);
 			path = Tests;
+			sourceTree = "<group>";
+		};
+		BF9C11A71D03566700449EA6 /* Configurations */ = {
+			isa = PBXGroup;
+			children = (
+				BF9C11AC1D03566700449EA6 /* UniversalFramework_Base.xcconfig */,
+				BF9C11AD1D03566700449EA6 /* UniversalFramework_Framework.xcconfig */,
+				BF9C11AE1D03566700449EA6 /* UniversalFramework_Test.xcconfig */,
+			);
+			name = Configurations;
+			path = Carthage/Checkouts/xcconfigs;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -349,6 +364,7 @@
 /* Begin XCBuildConfiguration section */
 		707F997C1C13B9EB00CE1A23 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = BF9C11AC1D03566700449EA6 /* UniversalFramework_Base.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -396,6 +412,7 @@
 		};
 		707F997D1C13B9EB00CE1A23 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = BF9C11AC1D03566700449EA6 /* UniversalFramework_Base.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -435,6 +452,7 @@
 		};
 		707F997F1C13B9EB00CE1A23 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = BF9C11AD1D03566700449EA6 /* UniversalFramework_Framework.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -455,6 +473,7 @@
 		};
 		707F99801C13B9EB00CE1A23 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = BF9C11AD1D03566700449EA6 /* UniversalFramework_Framework.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -474,6 +493,7 @@
 		};
 		707F99821C13B9EB00CE1A23 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = BF9C11AE1D03566700449EA6 /* UniversalFramework_Test.xcconfig */;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
@@ -484,6 +504,7 @@
 		};
 		707F99831C13B9EB00CE1A23 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = BF9C11AE1D03566700449EA6 /* UniversalFramework_Test.xcconfig */;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";

--- a/SwiftSequence.xcodeproj/project.xcworkspace/xcshareddata/SwiftSequence.xcscmblueprint
+++ b/SwiftSequence.xcodeproj/project.xcworkspace/xcshareddata/SwiftSequence.xcscmblueprint
@@ -1,0 +1,30 @@
+{
+  "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey" : "14502BA339D6D5207A23319C456924A2D72458F0",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyRepositoryLocationsKey" : {
+
+  },
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey" : {
+    "14502BA339D6D5207A23319C456924A2D72458F0" : 0,
+    "2DDF1D4E528EDA8D8E5AF503BA5680A30604BD70" : 0
+  },
+  "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "4EF82DEF-6DE4-4CC1-AB8D-D9C36D7C881D",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
+    "14502BA339D6D5207A23319C456924A2D72458F0" : "SwiftSequence\/",
+    "2DDF1D4E528EDA8D8E5AF503BA5680A30604BD70" : "SwiftSequence\/SwiftSequence\/Configurations\/"
+  },
+  "DVTSourceControlWorkspaceBlueprintNameKey" : "SwiftSequence",
+  "DVTSourceControlWorkspaceBlueprintVersion" : 204,
+  "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey" : "SwiftSequence.xcodeproj",
+  "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey" : [
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "https:\/\/github.com\/oisdk\/SwiftSequence.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "14502BA339D6D5207A23319C456924A2D72458F0"
+    },
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "https:\/\/github.com\/mrackwitz\/xcconfigs.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "2DDF1D4E528EDA8D8E5AF503BA5680A30604BD70"
+    }
+  ]
+}

--- a/SwiftSequence/SwiftSequence.h
+++ b/SwiftSequence/SwiftSequence.h
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Donnacha Oisín Kidney. All rights reserved.
 //
 
-#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
 
 //! Project version number for SwiftSequence.
 FOUNDATION_EXPORT double SwiftSequenceVersionNumber;
@@ -15,5 +15,3 @@ FOUNDATION_EXPORT double SwiftSequenceVersionNumber;
 FOUNDATION_EXPORT const unsigned char SwiftSequenceVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <SwiftSequence/PublicHeader.h>
-
-


### PR DESCRIPTION
Cocoapods does the build configuration on its own. As such it is not necessary to have multiple framework targets for supporting iOS & OS X & etc.

Carthage on the other hand requires a shared framework target to be found. In its current state **SwiftSequence** only provides a framework target for OS X.

By adding a Cartfile with `github "mrackwitz/xcconfigs"` I turned the existing framework target into a universal one (now supporting OS X, iOS, watchOS, tvOS, … out of the box).

Note that this is all optional!

You simply get Carthage support and universal frameworks for free, when you need it.
Up until you run `carthage checkout` **SwiftSequence** simply compiles like it used to.

But as soon as you run `carthage checkout` in your project the framework turns into a universal one (by pointing Xcode to the xcconfigs now found in `./Carthage/Checkouts/xcconfigs/`).
