### PR TITLE
Simplified universal framework config. Without depedencies.

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,0 @@
-github "mrackwitz/xcconfigs"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,0 @@
-github "mrackwitz/xcconfigs" "3.0"

--- a/SwiftSequence.xcodeproj/Configs/Project.xcconfig
+++ b/SwiftSequence.xcodeproj/Configs/Project.xcconfig
@@ -1,0 +1,1 @@
+SUPPORTED_PLATFORMS = macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator

--- a/SwiftSequence.xcodeproj/project.pbxproj
+++ b/SwiftSequence.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		70CB76F61C13BFD9003A7461 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CB76D61C13BFC0003A7461 /* TestHelpers.swift */; };
 		70CB76F71C13BFD9003A7461 /* ZipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CB76D71C13BFC0003A7461 /* ZipTests.swift */; };
 		70CB76FA1C13C03E003A7461 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 707F997B1C13B9EB00CE1A23 /* Info.plist */; };
+		BF92E1F01D11E63100FF4029 /* Project.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = BF92E1EF1D11E63100FF4029 /* Project.xcconfig */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -94,9 +95,7 @@
 		70CB76D51C13BFC0003A7461 /* TakeDropTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TakeDropTests.swift; sourceTree = "<group>"; };
 		70CB76D61C13BFC0003A7461 /* TestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		70CB76D71C13BFC0003A7461 /* ZipTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZipTests.swift; sourceTree = "<group>"; };
-		BF9C11AC1D03566700449EA6 /* UniversalFramework_Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = UniversalFramework_Base.xcconfig; sourceTree = "<group>"; };
-		BF9C11AD1D03566700449EA6 /* UniversalFramework_Framework.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = UniversalFramework_Framework.xcconfig; sourceTree = "<group>"; };
-		BF9C11AE1D03566700449EA6 /* UniversalFramework_Test.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = UniversalFramework_Test.xcconfig; sourceTree = "<group>"; };
+		BF92E1EF1D11E63100FF4029 /* Project.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Project.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -121,9 +120,9 @@
 		707F99601C13B9EA00CE1A23 = {
 			isa = PBXGroup;
 			children = (
+				BF92E1EE1D11E63100FF4029 /* Configs */,
 				707F996C1C13B9EA00CE1A23 /* Sources */,
 				707F99781C13B9EB00CE1A23 /* Tests */,
-				BF9C11A71D03566700449EA6 /* Configurations */,
 				707F996B1C13B9EA00CE1A23 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -188,15 +187,13 @@
 			path = Tests;
 			sourceTree = "<group>";
 		};
-		BF9C11A71D03566700449EA6 /* Configurations */ = {
+		BF92E1EE1D11E63100FF4029 /* Configs */ = {
 			isa = PBXGroup;
 			children = (
-				BF9C11AC1D03566700449EA6 /* UniversalFramework_Base.xcconfig */,
-				BF9C11AD1D03566700449EA6 /* UniversalFramework_Framework.xcconfig */,
-				BF9C11AE1D03566700449EA6 /* UniversalFramework_Test.xcconfig */,
+				BF92E1EF1D11E63100FF4029 /* Project.xcconfig */,
 			);
-			name = Configurations;
-			path = Carthage/Checkouts/xcconfigs;
+			name = Configs;
+			path = SwiftSequence.xcodeproj/Configs;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -290,6 +287,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BF92E1F01D11E63100FF4029 /* Project.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -364,7 +362,7 @@
 /* Begin XCBuildConfiguration section */
 		707F997C1C13B9EB00CE1A23 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BF9C11AC1D03566700449EA6 /* UniversalFramework_Base.xcconfig */;
+			baseConfigurationReference = BF92E1EF1D11E63100FF4029 /* Project.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -412,7 +410,7 @@
 		};
 		707F997D1C13B9EB00CE1A23 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BF9C11AC1D03566700449EA6 /* UniversalFramework_Base.xcconfig */;
+			baseConfigurationReference = BF92E1EF1D11E63100FF4029 /* Project.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -452,7 +450,6 @@
 		};
 		707F997F1C13B9EB00CE1A23 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BF9C11AD1D03566700449EA6 /* UniversalFramework_Framework.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -473,7 +470,6 @@
 		};
 		707F99801C13B9EB00CE1A23 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BF9C11AD1D03566700449EA6 /* UniversalFramework_Framework.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -493,7 +489,6 @@
 		};
 		707F99821C13B9EB00CE1A23 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BF9C11AE1D03566700449EA6 /* UniversalFramework_Test.xcconfig */;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
@@ -504,7 +499,6 @@
 		};
 		707F99831C13B9EB00CE1A23 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BF9C11AE1D03566700449EA6 /* UniversalFramework_Test.xcconfig */;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";


### PR DESCRIPTION
Hi Oisin,

this is basically a cleanup for PR https://github.com/oisdk/SwiftSequence/pull/7.

Turns out that with SwiftSequence being a pure Swift framework without any further dependencies of its own, the use of [xcconfigs](https://github.com/mrackwitz/xcconfigs) as a carthage dependency for simply making `SUPPORTED_PLATFORMS` universal was a bit overkill.

Hence I removed the cartfile and simply included a minimal xcconfig with nothing but `SUPPORTED_PLATFORMS = …` in it. Works just as well as with [xcconfigs](https://github.com/mrackwitz/xcconfigs) but with way fewer moving parts now.

Support for Carthage, CocoaPods, etc remains. It just doesn't have a carthage dependency on its own anymore.

Sorry for the inconveniences. :(
